### PR TITLE
Create stub-able CLI#yes?, Git#fetch now correctly prints to $stderr

### DIFF
--- a/lib/loca/cli.rb
+++ b/lib/loca/cli.rb
@@ -35,5 +35,13 @@ module Loca
       git.delete
       say "Deleted #{branch_name}!", :green
     end
+
+    private # rubocop:disable Lint/UselessAccessModifier
+
+    no_commands do # Thor primitive(s) that we want to stub in RSpec
+      def yes?(*args)
+        super
+      end
+    end
   end
 end

--- a/lib/loca/git.rb
+++ b/lib/loca/git.rb
@@ -22,7 +22,7 @@ module Loca
     end
 
     def checkout
-      @git.branch(@branch_name).checkout
+      git "checkout #{@branch_name}"
     end
 
     def fetch
@@ -45,7 +45,7 @@ module Loca
       if fail_on_stderr
         fail Loca::GitException, "#{shellout.stderr}"
       else
-        puts shellout.stderr.red
+        $stderr.puts shellout.stderr.red
       end
       shellout.stdout
     end
@@ -68,20 +68,19 @@ module Loca
     end
 
     def checkout_another_branch
-      puts "branches: #{branches}".yellow
       another = branches.find { |branch| branch != current_branch }
-      puts "another: #{another}".yellow
-      @git.branch(another).checkout
+      fail Loca::GitException, 'No other branch to checkout!' unless another
+      git "checkout #{another}"
     end
 
     def extract_remote_name
       mapping = {}
       @git.remotes.each do |remote|
-        mapping[remote.name] = remote.url.sub(/.git$/, '') # Strip off trailing '.git'
+        mapping[remote.name] = remote.url.sub('git://', '').sub(/.git$/, '') # Strip off uri scheme & trailing '.git'
       end
 
       match = mapping.select { |_name, url| @url.to_s.include? url }
-      fail Loca::GitException, 'You must set the repo as a remote '\
+      fail Loca::GitException, "You must set the repo (#{@url}) as a remote "\
       "(see `git remote -v'). All remotes: #{mapping}" if match.empty?
       match.keys.first
     end

--- a/spec/loca/cli_spec.rb
+++ b/spec/loca/cli_spec.rb
@@ -1,7 +1,64 @@
 describe Loca::CLI do
+  let(:invalid_url) { 'https://github.com/fakez/fakezz/pull/1' }
+  let(:url) { 'https://github.com/smoll/loca/pull/1' }
+  subject { described_class.new }
+
+  before do # ensure we don't shell out to git
+    allow_any_instance_of(Loca::Git).to receive(:fetch)
+    allow_any_instance_of(Loca::Git).to receive(:checkout)
+  end
+
   describe 'c' do
+    it 'fetches and checks out the branch locally' do
+      expect_any_instance_of(Loca::Git).to receive(:branch_name).and_return 'PULL_1'
+      expect_any_instance_of(Loca::Git).to receive(:first_time_creating?).and_return true
+
+      output = capture(:stdout) { Loca::CLI.start(%W(c #{url})) }.strip
+      expect(output).to end_with 'Checked out PULL_1!'
+    end
+
+    it 'fetches and overwrites existing branch if the user says yes to overwrite' do
+      expect_any_instance_of(Loca::Git).to receive(:branch_name).and_return 'PULL_1'
+      expect_any_instance_of(Loca::Git).to receive(:first_time_creating?).and_return false
+
+      allow_any_instance_of(described_class).to receive(:yes?).and_return true # TODO: silence this [WARNING] puts
+
+      output = capture(:stdout) { Loca::CLI.start(%W(c #{url})) }.strip
+      expect(output).to end_with 'Checked out PULL_1!'
+    end
+
+    it 'raises an error when the branch exists and the user says no to overwrite' do
+      expect_any_instance_of(Loca::Git).to receive(:branch_name).and_return 'PULL_1'
+      expect_any_instance_of(Loca::Git).to receive(:first_time_creating?).and_return false
+      allow_any_instance_of(described_class).to receive(:yes?).and_return false # TODO: silence this [WARNING] puts
+
+      expect { silence(:stderr) { Loca::CLI.start(%W(c #{url})) } }.to raise_error
+    end
+
     it 'raises an error when an invalid repo is supplied' do
-      expect { silence(:stderr) { Loca::CLI.start(%w(c https://github.com/fakez/fakezz/pull/1)) } }.to raise_error
+      expect { silence(:stderr) { Loca::CLI.start(%W(c #{invalid_url})) } }.to raise_error
+    end
+
+    it 'deletes when the delete flag is appended' do
+      expect_any_instance_of(Loca::Git).to receive(:branch_name).and_return 'PULL_1'
+      expect_any_instance_of(Loca::Git).to receive(:delete)
+
+      output = capture(:stdout) { Loca::CLI.start(%W(c #{url} -d)) }.strip
+      expect(output).to eq 'Deleted PULL_1!'
+    end
+  end
+
+  describe 'd' do
+    it 'deletes' do
+      expect_any_instance_of(Loca::Git).to receive(:branch_name).and_return 'PULL_1'
+      expect_any_instance_of(Loca::Git).to receive(:delete)
+
+      output = capture(:stdout) { Loca::CLI.start(%W(d #{url})) }.strip
+      expect(output).to eq 'Deleted PULL_1!'
+    end
+
+    it 'raises an error when an invalid repo is supplied' do
+      expect { silence(:stderr) { Loca::CLI.start(%W(d #{invalid_url})) } }.to raise_error
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,8 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect # Disable `should_receive` and `stub`
+    mocks.verify_partial_doubles = true # Avoid La La Land,
+    # read http://wegowise.github.io/blog/2014/09/03/rspec-verifying-doubles/
   end
 
   config.before do


### PR DESCRIPTION
Also replace the implementations for Loca::Git#checkout and
# checkout_another_branch to make them more unit-testable

Also shore up simplecov test coverage to 99%!
